### PR TITLE
Non-Existing-Keys

### DIFF
--- a/FSwift/Optional/Decoder.swift
+++ b/FSwift/Optional/Decoder.swift
@@ -12,23 +12,38 @@ import Swift
 public extension Decoder {
     
     public var string: String? {
-        return self.val as? String
+        if let _val = self.val {
+            return _val as? String
+        }
+        return nil
     }
     
     public var int: Int? {
-        return self.val as? Int
+        if let _val = self.val {
+            return _val as? Int
+        }
+        return nil
     }
     
     public var double: Double? {
-        return self.val as? Double
+        if let _val = self.val {
+            return _val as? Double
+        }
+        return nil
     }
     
     public var float: Float? {
-        return self.val as? Float
+        if let _val = self.val {
+            return _val as? Float
+        }
+        return nil
     }
     
     public var bool: Bool? {
-        return self.val as? Bool
+        if let _val = self.val {
+            return _val as? Bool
+        }
+        return nil
     }
     
     public var errorMessage: String? {


### PR DESCRIPTION
### Issue

When trying Decoder["keyname"] in a JSON which does not have key with key name as "keyname", it would be ideal if the Library itself returns a nil value instead of crashing.

for example Decoder["keyname"] for json

``` javascript
{
"keyname" : "value"
}
```

will return "value" but crash for json

``` javascript
{
"otherKeyName" : "value"
}
```
### Changes

If the value does not exist returning nil for each type. This should avoid the crash.
